### PR TITLE
fix: Update image paths for renamed repository

### DIFF
--- a/.github/workflows/rebuild-dependencies.yml
+++ b/.github/workflows/rebuild-dependencies.yml
@@ -40,9 +40,9 @@ jobs:
           context: .
           push: true
           tags: |
-            ghcr.io/brianfromm/youtube-video-extractor:latest
-            ghcr.io/brianfromm/youtube-video-extractor:${{ steps.date.outputs.date }}
-            ghcr.io/brianfromm/youtube-video-extractor:build-${{ github.run_number }}
+            ghcr.io/brianfromm/youtube-downloader:latest
+            ghcr.io/brianfromm/youtube-downloader:${{ steps.date.outputs.date }}
+            ghcr.io/brianfromm/youtube-downloader:build-${{ github.run_number }}
           pull: true  # Pull latest base images
           no-cache: true  # Force fresh dependency downloads
           platforms: linux/amd64,linux/arm64
@@ -55,9 +55,9 @@ jobs:
           echo "**Reason**: ${{ github.event.inputs.reason || 'Scheduled dependency update' }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "#### 📦 Images Published:" >> $GITHUB_STEP_SUMMARY
-          echo "- \`ghcr.io/brianfromm/youtube-video-extractor:latest\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`ghcr.io/brianfromm/youtube-video-extractor:${{ steps.date.outputs.date }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`ghcr.io/brianfromm/youtube-video-extractor:build-${{ github.run_number }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`ghcr.io/brianfromm/youtube-downloader:latest\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`ghcr.io/brianfromm/youtube-downloader:${{ steps.date.outputs.date }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`ghcr.io/brianfromm/youtube-downloader:build-${{ github.run_number }}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Platforms**: linux/amd64, linux/arm64" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,62 @@
+# YouTube Downloader - Claude Code Reference
+
+## Project Overview
+Web-based YouTube video analyzer and downloader built with Flask, yt-dlp, and FFmpeg. Features automated dependency updates and file cleanup for minimal maintenance.
+
+## Key Commands
+
+### Local Development
+```bash
+# Setup
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+
+# Run locally
+python server.py
+# Access: http://localhost:8080
+```
+
+### Docker Commands
+```bash
+# Build and run
+docker-compose up --build -d
+
+# Update dependencies manually
+docker-compose pull
+docker-compose up -d --remove-orphans
+
+# View logs
+docker-compose logs -f
+```
+
+### GitHub Actions
+- **Weekly rebuilds**: Every Sunday 3am MT
+- **Manual trigger**: Actions → "Rebuild with Latest Dependencies"
+- **Image location**: `ghcr.io/brianfromm/youtube-downloader:latest`
+
+## Important Files
+- `server.py` - Main Flask application with task queue
+- `.github/workflows/rebuild-dependencies.yml` - Automated dependency updates
+- `processed_files/` - Auto-cleaned after 7 days, descriptive filenames
+- `PROCESSED_FILES_DIR` - Uses descriptive names like "Title (1080p) [uuid8].mp4"
+
+## Environment Variables
+```env
+# Production
+COMPOSE_IMAGE=ghcr.io/brianfromm/youtube-downloader:latest
+USE_DEV_SERVER=false
+GUNICORN_WORKERS=1  # MUST be 1 due to in-memory queue
+```
+
+## Automation Features
+- **File cleanup**: Automatic removal of files older than 7 days
+- **Dependency updates**: Weekly yt-dlp and FFmpeg updates via GitHub Actions
+- **Descriptive storage**: Files stored with video title + quality info
+- **Watchtower ready**: Auto-deployment when new images available
+
+## Architecture Notes
+- In-memory task queue (requires single worker)
+- Background worker thread for processing
+- Dual codec support (direct merge + FFmpeg transcode)
+- Mobile-responsive UI (work in progress)

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,9 @@ WORKDIR /app
 # Copy requirements first for better caching
 COPY requirements.txt .
 
+# Upgrade pip to latest version first
+RUN pip install --no-cache-dir --upgrade pip
+
 # Install Python dependencies
 RUN pip install --no-cache-dir -r requirements.txt
 # Ensure yt-dlp is the absolute latest version

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Available environment variables:
 - **`COMPOSE_IMAGE`**:
   - **Purpose:** Specifies the Docker image name and tag to use.
   - **Local Development (in `.env.local`):** Set to a local-specific tag, e.g., `COMPOSE_IMAGE=youtube-extractor-local:latest`. When you run `docker-compose build`, the locally built image will be tagged with this name.
-  - **Production (in `.env` on server):** Set to your pre-built production image URL, e.g., `COMPOSE_IMAGE=ghcr.io/brianfromm/youtube-video-extractor:latest`. This allows Watchtower (or manual pulls) to use the correct production image.
+  - **Production (in `.env` on server):** Set to your pre-built production image URL, e.g., `COMPOSE_IMAGE=ghcr.io/brianfromm/youtube-downloader:latest`. This allows Watchtower (or manual pulls) to use the correct production image.
   - **Default (if not set):** Defaults to `youtube-extractor-default:latest` in `docker-compose.yml`, intended for local builds if no specific `COMPOSE_IMAGE` is provided.
 
 - **`COMPOSE_PLATFORM`**:
@@ -135,7 +135,7 @@ USE_DEV_SERVER=true
 
 **Example `.env` for a production Synology NAS (amd64):**
 ```
-COMPOSE_IMAGE=ghcr.io/brianfromm/youtube-video-extractor:latest
+COMPOSE_IMAGE=ghcr.io/brianfromm/youtube-downloader:latest
 USE_DEV_SERVER=false
 GUNICORN_WORKERS=1 # IMPORTANT: Must be 1 due to in-memory task queue
 GUNICORN_THREADS=4 # Default, can be adjusted based on NAS performance
@@ -152,8 +152,8 @@ HOST_PORT=8080 # Standard host mapping for this service
 
 1.  **Clone the repository:**
     ```bash
-    git clone https://github.com/brianfromm/youtube-video-extractor.git
-    cd youtube-video-extractor
+    git clone https://github.com/brianfromm/youtube-downloader.git
+    cd youtube-downloader
     ```
 
 2.  **Create and activate a virtual environment (recommended):**
@@ -181,8 +181,8 @@ HOST_PORT=8080 # Standard host mapping for this service
 
 1.  **Clone the repository (if not already done):**
     ```bash
-    git clone https://github.com/brianfromm/youtube-video-extractor.git
-    cd youtube-video-extractor
+    git clone https://github.com/brianfromm/youtube-downloader.git
+    cd youtube-downloader
     ```
 
 2.  **Using `docker-compose` (recommended for Docker):**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     # - For local development: Set COMPOSE_IMAGE in '.env.local' (e.g., COMPOSE_IMAGE=youtube-extractor-local:latest).
     #   This will build and use a local image with that tag.
     # - For production (e.g., Synology NAS with Watchtower): Set COMPOSE_IMAGE in an '.env' file on the server
-    #   (or via Container Manager environment settings) to your production image (e.g., COMPOSE_IMAGE=ghcr.io/brianfromm/youtube-video-extractor:latest).
+    #   (or via Container Manager environment settings) to your production image (e.g., COMPOSE_IMAGE=ghcr.io/brianfromm/youtube-downloader:latest).
     # - If COMPOSE_IMAGE is not set in any .env file, it defaults to 'youtube-extractor-default:latest' for local builds.
     image: ${COMPOSE_IMAGE:-youtube-extractor-default:latest}
     build:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -27,7 +27,7 @@ This is the recommended method for deploying on a server like a Synology NAS.
 
     services:
       youtube-extractor:
-        image: ${COMPOSE_IMAGE:-ghcr.io/brianfromm/youtube-video-extractor:latest} # Or your specific production image
+        image: ${COMPOSE_IMAGE:-ghcr.io/brianfromm/youtube-downloader:latest} # Or your specific production image
         container_name: youtube-extractor
         restart: unless-stopped
         ports:
@@ -58,7 +58,7 @@ This is the recommended method for deploying on a server like a Synology NAS.
     # --- Production .env for YouTube Video Extractor ---
 
     # Docker Image Configuration
-    COMPOSE_IMAGE=ghcr.io/brianfromm/youtube-video-extractor:latest # Replace with your actual production image and tag
+    COMPOSE_IMAGE=ghcr.io/brianfromm/youtube-downloader:latest # Replace with your actual production image and tag
 
     # Docker Build Configuration (primarily for local builds or if building on the server and need to specify target)
     # COMPOSE_PLATFORM=linux/amd64  # Example: For Synology NAS (amd64), often not needed if image is already amd64.
@@ -89,7 +89,7 @@ This is the recommended method for deploying on a server like a Synology NAS.
     ```
     Or, more explicitly:
     ```bash
-    docker pull ghcr.io/brianfromm/youtube-video-extractor:latest # Or your image
+    docker pull ghcr.io/brianfromm/youtube-downloader:latest # Or your image
     ```
 
 5.  **Start the Application:**


### PR DESCRIPTION
- Update GitHub Actions workflow to push to ghcr.io/brianfromm/youtube-downloader
- Update all documentation references to new repository name
- Add pip upgrade to Dockerfile for always-fresh builds
- Create comprehensive CLAUDE.md reference guide

Fixes the GitHub Actions push error after repository rename.