### PR TITLE
fix: resolve semantic-release dependency error

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -24,7 +24,7 @@
     [
       "@semantic-release/release-notes-generator",
       {
-        "preset": "conventionalcommits",
+        "preset": "angular",
         "presetConfig": {
           "types": [
             { "type": "feat", "section": "🚀 Features", "hidden": false },
@@ -40,9 +40,6 @@
             { "type": "build", "section": "📦 Build System", "hidden": false },
             { "type": "ci", "section": "🔄 CI/CD", "hidden": false }
           ]
-        },
-        "writerOpts": {
-          "commitsSort": ["subject", "scope"]
         }
       }
     ],


### PR DESCRIPTION
- Change preset from 'conventionalcommits' to 'angular' to avoid missing dependency
- Remove writerOpts configuration that required additional package
- Keep enhanced release notes with emoji categories and organized sections
- This fixes the 'Cannot find module conventional-changelog-conventionalcommits' error

The release notes will still be organized and detailed, just using the built-in angular preset.